### PR TITLE
prepare 1.0.2 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "LaunchDarkly Client-side SDK for VueJS",
   "main": "./dist/launchdarkly-vue-client-sdk.umd.js",
   "types": "./dist/src/index.d.ts",
+  "files": [
+    "dist",
+    "src",
+    "!**/*.test.*"
+  ],
   "engines": {
     "npm": ">=8.11.0",
     "node": ">=16.15.1"


### PR DESCRIPTION
## [1.0.2] - 2022-08-11
### Fixed:
- Remove some unnecessary files, reducing package size