### PR TITLE
prepare 1.1.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/launchdarkly/vue-client-sdk-private#readme",
   "dependencies": {
-    "launchdarkly-js-client-sdk": "2.22.1"
+    "launchdarkly-js-client-sdk": "2.23.0"
   },
   "devDependencies": {
     "@types/jest": "^28.1.3",


### PR DESCRIPTION
## [1.1.0] - 2022-10-05
### Changed:
- Updated `js-client-sdk` version which removed event de-duplication functionality which was made redundant by support of summary events. This will improve the default event behavior when using experimentation.