### PR TITLE
prepare 1.2.1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/launchdarkly/vue-client-sdk-private#readme",
   "dependencies": {
-    "launchdarkly-js-client-sdk": "2.24.0"
+    "launchdarkly-js-client-sdk": "2.24.2"
   },
   "devDependencies": {
     "@types/jest": "^28.1.3",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/launchdarkly/vue-client-sdk-private#readme",
   "dependencies": {
-    "launchdarkly-js-client-sdk": "2.22.1"
+    "launchdarkly-js-client-sdk": "2.23.0"
   },
   "devDependencies": {
     "@types/jest": "^28.1.3",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/launchdarkly/vue-client-sdk-private#readme",
   "dependencies": {
-    "launchdarkly-js-client-sdk": "2.23.0"
+    "launchdarkly-js-client-sdk": "2.24.0"
   },
   "devDependencies": {
     "@types/jest": "^28.1.3",


### PR DESCRIPTION
## [1.2.1] - 2022-10-21
### Changed:
- Upgraded to `js-client-sdk` version `2.24.2` which includes implementations of `jitter` and `backoff` for streaming connections. When a connection fails the retry will start at the `streamReconnectDelay` and will double on each unsuccessful consecutive connection attempt (`backoff`) to a max of 30 seconds. The delay will be adjusted from 50%-100% of the calculated delay to prevent many clients from attempting to reconnect at the same time (`jitter`).