### PR TITLE
Add vue router guard

### DIFF
--- a/src/guards.test.ts
+++ b/src/guards.test.ts
@@ -1,0 +1,75 @@
+import { launchDarklyGuard } from './guards'
+
+const existingFlagKey = 'random-flag-key'
+const existingFlagValue = 'random-flag-value'
+
+jest.mock('./utils', () => ({
+  watchEffectOnceAsync: () => Promise.resolve(),
+}))
+
+jest.mock('.', () => ({
+  launchDarklyClient: {
+    value: {
+      variation: (flagKey: string, defaultValue?: unknown) => {
+        if (existingFlagKey === flagKey) {
+          return existingFlagValue
+        }
+
+        return defaultValue
+      },
+    },
+  },
+}))
+
+describe('guards', () => {
+  const genericFlag = 'myFlag'
+  const genericDefaultValue = 'default-value'
+  const genericArgs: unknown = []
+  const genericCallback = () => genericDefaultValue
+
+  const warnSpy = jest.spyOn(global.console, 'warn').mockImplementation(() => undefined)
+
+  test('should return a function', () => {
+    expect(launchDarklyGuard(existingFlagKey)).toMatchInlineSnapshot(`[Function]`)
+  })
+
+  test('should return a promise after invocation', () => {
+    expect(launchDarklyGuard(existingFlagKey)(genericArgs)).toMatchInlineSnapshot(`Promise {}`)
+  })
+
+  test('should return undefined when the flag does not exist', async () => {
+    const result = await launchDarklyGuard(genericFlag)(genericArgs)
+    expect(result).toMatchInlineSnapshot(`undefined`)
+  })
+
+  test('should return the default value', async () => {
+    const result = await launchDarklyGuard(genericFlag, null, genericDefaultValue)(genericArgs)
+    expect(result).toBe(genericDefaultValue)
+  })
+
+  test('should return the callback value', async () => {
+    const result = await launchDarklyGuard(genericFlag, genericCallback)(genericArgs)
+    expect(result).toBe(genericDefaultValue)
+  })
+
+  test('should return the callback value (true)', async () => {
+    const callbackValue = true
+    const result = await launchDarklyGuard(genericFlag, () => callbackValue)(genericArgs)
+    expect(result).toBe(callbackValue)
+  })
+
+  test('should return the callback value (false)', async () => {
+    const callbackValue = false
+    const result = await launchDarklyGuard(genericFlag, () => callbackValue)(genericArgs)
+    expect(result).toBe(callbackValue)
+  })
+
+  test('should return the existing value (simulates a Launch Darkly real value)', async () => {
+    const result = await launchDarklyGuard(existingFlagKey)(genericArgs)
+    expect(result).toBe(existingFlagValue)
+  })
+
+  test('should have called console.warn)', async () => {
+    expect(warnSpy).toHaveBeenCalled()
+  })
+})

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -1,0 +1,38 @@
+import { unref } from 'vue'
+import { launchDarklyClient, launchDarklyReady } from '.'
+import { watchEffectOnceAsync } from './utils'
+
+/**
+ * Vue Router Guard.
+ *
+ * Provides a way to access flag values in the vue-router guards.
+ * [per-route-guard](https://router.vuejs.org/guide/advanced/navigation-guards.html#per-route-guard)
+ * Usage: `beforeEnter: launchDarklyGuard(flagKey, callback, defaultValue),`
+ *
+ * Custom logic can be apply using the callback parameter, when this parameter is passed it will be
+ * in charge of the guard logic. The 'callback' function will hold the resulted flag and the injected
+ * Vue Router params, check: [NavigationGuard](https://router.vuejs.org/api/interfaces/NavigationGuard.html)
+ */
+export function launchDarklyGuard<T>(flagKey: string, callback?: ((arg0: boolean, args: unknown) => void) | null, defaultValue?: T): (args: unknown) => Promise<boolean> {
+  return async (...args) => {
+    const fn = () => {
+      const flag = launchDarklyClient.value.variation(flagKey, defaultValue)
+
+      if (typeof flag !== 'boolean' && typeof callback !== 'function') {
+        console.warn(`LaunchDarkly guard warning: Be careful, flag key '${flagKey}' does not returns boolean value (${flag}), therefore it can lead to unexpected results.`)
+      }
+
+      if (typeof callback === 'function') {
+        return callback(flag, ...args)
+      }
+
+      return flag
+    }
+
+    if (!unref(launchDarklyReady)) {
+      await watchEffectOnceAsync(() => unref(launchDarklyReady))
+    }
+
+    return fn()
+  }
+}

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,36 @@
+import { ref, unref, nextTick } from 'vue'
+import { watchEffectOnceAsync, watchEffectOnce } from './utils'
+
+describe('utils', () => {
+  const genericReactiveValue = ref(false)
+  let genericCallback = jest.fn()
+  let genericWatcher = () => unref(genericReactiveValue)
+
+  function reset() {
+    genericCallback.mockReset()
+    genericReactiveValue.value = false
+    genericCallback = jest.fn()
+    genericWatcher = () => unref(genericReactiveValue)
+  }
+
+  test('watchEffectOnce', async () => {
+    reset()
+    watchEffectOnce(genericWatcher, genericCallback)
+    genericReactiveValue.value = true
+    await nextTick()
+
+    expect(genericCallback).toBeCalled()
+  })
+
+  test('watchEffectOnceAsync', async () => {
+    reset()
+    const fulfilledStatus = 'fulfilled'
+    const resultPromise = watchEffectOnceAsync(genericWatcher)
+    genericReactiveValue.value = true
+    await nextTick()
+    const resultPromiseSettlement = await Promise.allSettled([resultPromise])
+    const resultPromiseStatus = (resultPromiseSettlement.pop() || {}).status
+
+    expect(resultPromiseStatus).toBe(fulfilledStatus)
+  })
+})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,28 @@
+import { watchEffect } from 'vue'
+
+/**
+ * @ignore
+ * Run watchEffect until the watcher returns true, then stop the watch.
+ * Once it returns true, the promise will resolve.
+ * [Reference](https://github.com/auth0/auth0-vue/blob/main/src/utils.ts)
+ */
+export function watchEffectOnceAsync<T>(watcher: () => T) {
+  return new Promise<void>(resolve => {
+    watchEffectOnce(watcher, resolve)
+  })
+}
+
+/**
+ * @ignore
+ * Run watchEffect until the watcher returns true, then stop the watch.
+ * Once it returns true, it will call the provided function.
+ * [Reference](https://github.com/auth0/auth0-vue/blob/main/src/utils.ts)
+ */
+export function watchEffectOnce<T>(watcher: () => T, fn: (value: void | PromiseLike<void>) => void) {
+  const stopWatch = watchEffect(() => {
+    if (watcher()) {
+      fn()
+      stopWatch()
+    }
+  })
+}


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions. (**Which are the supported platforms?**)

**Related issues**
None.

**Describe the solution you've provided**
- These changes enable guard usage within the [Vue Router](https://router.vuejs.org/) library.
- It makes available the Launch Darkly instance which enables cross-sharing functionality.
- It makes available the Launch Darkly instance readiness which enables cross-sharing functionality.
- `launchDarklyGuard`:
  - Can be used to check a specific flag value and avoid page interaction if the result is `false`
  ```js
  import { launchDarklyGuard } from "launchdarkly-vue-client-sdk";

  export const routes = [
    {
      path: "/my-route",
      name: "my-route",
      component: MyComponent,
      beforeEnter: launchDarklyGuard("CUSTOM_KEY"),
    },
  ];
  ``` 
  - Can be used to apply custom logic by passing a callback parameter:
  ```js
  import { launchDarklyGuard } from "launchdarkly-vue-client-sdk";

  export const launchDarklyCustomGuard = launchDarklyGuard("CUSTOM_KEY", (flag, to, from, next) => {
    /** to, from, next <-- Values from router https://router.vuejs.org/api/interfaces/NavigationGuard.html */

    if (flag) { /** <-- returned value from Launch Darkly */
      return /** Here you can return true, false, or a route */
    }

    return /** Here you can return true, false, or a route */
  });
  ``` 

**Describe alternatives you've considered**
Component-based guard https://github.com/dashhudson/vue-ld#ldrouteguard-component

**Additional context**
Guard-based validation helps to reduce the amount of feature flags logic across components, it gives a centralized way of controlling page access.

*I hope this sparks a conversation around Vue guards in LD :)*