### PR TITLE
fix: Fix incorrect flag update handling when streaming is disabled

### DIFF
--- a/src/getLDFlag.test.ts
+++ b/src/getLDFlag.test.ts
@@ -62,54 +62,6 @@ describe('when ld client is ready', () => {
   })
 })
 
-describe('when streaming is disabled', () => {
-  describe('and ld is not yet ready', () => {
-    let ldClient: LDClient
-    let flagRef: Readonly<Ref<string>>
-
-    beforeEach(() => {
-      onBeforeUnmountMocked.mockClear()
-      ldClient = getMockLdClient('test-flag-value')
-      flagRef = getLDFlag(ref(false), ldClient, false)('test-flag-key', 'default-flag-value')
-    })
-
-    test('returns ref to default flag value', () => {
-      expect(flagRef.value).toBe('default-flag-value')
-    })
-
-    test('does not set up event handlers', () => {
-      expect(ldClient.on).not.toHaveBeenCalled()
-    })
-
-    test('does not set up onBeforeUnmount handler', () => {
-      expect(onBeforeUnmount).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('and ld is ready', () => {
-    let ldClient: LDClient
-    let flagRef: Readonly<Ref<string>>
-
-    beforeEach(() => {
-      onBeforeUnmountMocked.mockClear()
-      ldClient = getMockLdClient('test-flag-value')
-      flagRef = getLDFlag(ref(true), ldClient, false)('test-flag-key', 'default-flag-value')
-    })
-
-    test('returns ref to flag value', () => {
-      expect(flagRef.value).toBe('test-flag-value')
-    })
-
-    test('does not set up event handlers', () => {
-      expect(ldClient.on).not.toHaveBeenCalled()
-    })
-
-    test('does not set up onBeforeUnmount handler', () => {
-      expect(onBeforeUnmount).not.toHaveBeenCalled()
-    })
-  })
-})
-
 test('onBeforeUnmount disables change event handler', () => {
   const ldClient = getMockLdClient('test-flag-value')
   getLDFlag(ref(true), ldClient)('test-flag-key', 'default-flag-value')

--- a/src/getLDFlag.ts
+++ b/src/getLDFlag.ts
@@ -3,14 +3,11 @@ import type { LDClient } from 'launchdarkly-js-client-sdk'
 
 export type FlagRef<T> = Readonly<Ref<T>>
 
-export const getLDFlag = (ldReady: Ref<boolean>, $ldClient: LDClient, enableStreaming = true) => {
+export const getLDFlag = (ldReady: Ref<boolean>, $ldClient: LDClient) => {
   return function ldFlag<T>(flagKey: string, defaultFlagValue?: T): FlagRef<T> {
     const isLdReady = ldReady.value
     const flagValue = isLdReady ? $ldClient.variation(flagKey, defaultFlagValue) : defaultFlagValue
     const flagRef = ref(flagValue)
-    if (!enableStreaming) {
-      return readonly(flagRef)
-    }
 
     const updateFlagRef = (newFlagValue: unknown) => (flagRef.value = newFlagValue)
     $ldClient.on(`change:${flagKey}`, updateFlagRef)

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -26,6 +26,7 @@ describe('LDPlugin', () => {
     provideMock.mockClear()
     onMock.mockClear()
     getLdFlagMock.mockClear()
+    initializeMock.mockClear()
   })
 
   test('throws if clientSideID is not provided', () => {
@@ -65,21 +66,43 @@ describe('LDPlugin', () => {
     expect($ldReady.value).toBe(true)
   })
 
-  test('defaults to streaming if not provided', () => {
+  test('streaming defaults to undefined if not provided', () => {
     LDPlugin.install(app, { clientSideID: 'hk47' })
 
-    expect(initializeMock).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.objectContaining({ streaming: true }))
-  });
-
-  test('passes streaming option through', () => {
-    LDPlugin.install(app, { clientSideID: 'hk47', streaming: false })
-
-    expect(initializeMock).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.objectContaining({ streaming: false }))
+    expect(initializeMock).toHaveBeenCalledWith(
+      'hk47',
+      expect.anything(),
+      expect.not.objectContaining({ streaming: expect.anything() }),
+    )
   })
 
-  test('overrides streaming if provided in options', () => {
+  test('passes streaming option through from plugin options', () => {
+    LDPlugin.install(app, { clientSideID: 'hk47', streaming: false })
+
+    expect(initializeMock).toHaveBeenCalledWith(
+      'hk47',
+      expect.anything(),
+      expect.objectContaining({ streaming: false }),
+    )
+  })
+
+  test('passes streaming option through from client options', () => {
+    LDPlugin.install(app, { clientSideID: 'hk47', options: { streaming: false } })
+
+    expect(initializeMock).toHaveBeenCalledWith(
+      'hk47',
+      expect.anything(),
+      expect.objectContaining({ streaming: false }),
+    )
+  })
+
+  test('streaming option from client options overrides plugin options', () => {
     LDPlugin.install(app, { clientSideID: 'hk47', streaming: false, options: { streaming: true } })
 
-    expect(initializeMock).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.objectContaining({ streaming: false }))
+    expect(initializeMock).toHaveBeenCalledWith(
+      'hk47',
+      expect.anything(),
+      expect.objectContaining({ streaming: true }),
+    )
   })
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -65,10 +65,21 @@ describe('LDPlugin', () => {
     expect($ldReady.value).toBe(true)
   })
 
-  test('passes enableStreaming option through', () => {
+  test('defaults to streaming if not provided', () => {
+    LDPlugin.install(app, { clientSideID: 'hk47' })
+
+    expect(initializeMock).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.objectContaining({ streaming: true }))
+  });
+
+  test('passes streaming option through', () => {
     LDPlugin.install(app, { clientSideID: 'hk47', streaming: false })
 
-    expect(getLdFlagMock).toHaveBeenCalledWith(expect.anything(), ldClientMock, false)
-    expect(getLdFlagMock.mock.calls[0][0]).toHaveProperty('value', false)
+    expect(initializeMock).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.objectContaining({ streaming: false }))
+  })
+
+  test('overrides streaming if provided in options', () => {
+    LDPlugin.install(app, { clientSideID: 'hk47', streaming: false, options: { streaming: true } })
+
+    expect(initializeMock).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.objectContaining({ streaming: false }))
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export type LDPluginOptions = {
 
   /**
    * Enables or disables automatically subscribing to live updates to flags referenced using {@link useLDFlag}.
+   * This value will always override the `streaming` property if it is provided in `options`.
    *
    * @defaultValue `true`
    */
@@ -96,13 +97,16 @@ export const LDPlugin = {
 
       const context = getContextOrUser(initOptions) ??
         getContextOrUser(pluginOptions) ?? { anonymous: true, kind: 'user' }
-      const options = initOptions.options ?? pluginOptions.options
+      const streaming = pluginOptions.streaming === false || initOptions.streaming === false ? false : true
+      const options = {
+        ...(initOptions.options ?? pluginOptions.options),
+        streaming,
+      }
       const wrapperOptions = { wrapperName: 'vue-client-sdk', wrapperVersion: version }
       const $ldClient = initialize(clientSideID, context, { ...wrapperOptions, ...options })
 
       app.provide(LD_CLIENT, $ldClient)
-      const enableStreaming = pluginOptions.streaming === false || initOptions.streaming === false ? false : true
-      app.provide(LD_FLAG, getLDFlag(ldReady, $ldClient, enableStreaming))
+      app.provide(LD_FLAG, getLDFlag(ldReady, $ldClient))
 
       $ldClient.on('ready', () => (ldReady.value = true))
       return [$ldReady, $ldClient]

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,10 +31,15 @@ export type LDPluginOptions = {
   user?: LDContext
 
   /**
-   * Enables or disables automatically subscribing to live updates to flags referenced using {@link useLDFlag}.
-   * This value will always override the `streaming` property if it is provided in `options`.
+   * Whether or not to open a streaming connection to LaunchDarkly for live flag updates.
    *
-   * @defaultValue `true`
+   * If this is true, the client will always attempt to maintain a streaming connection; if false,
+   * it never will. If you leave the value undefined (the default), the client will open a streaming
+   * connection for live updates to flags referenced using {@link useLDFlag}.
+   *
+   * Note that if `streaming` is provided in `options`, it will take precedence.
+   *
+   * @defaultValue `undefined`
    */
   streaming?: boolean
 
@@ -97,10 +102,11 @@ export const LDPlugin = {
 
       const context = getContextOrUser(initOptions) ??
         getContextOrUser(pluginOptions) ?? { anonymous: true, kind: 'user' }
-      const streaming = pluginOptions.streaming === false || initOptions.streaming === false ? false : true
+
+      const streaming = initOptions.streaming ?? pluginOptions.streaming
       const options = {
+        ...(streaming !== undefined ? { streaming } : {}),
         ...(initOptions.options ?? pluginOptions.options),
-        streaming,
       }
       const wrapperOptions = { wrapperName: 'vue-client-sdk', wrapperVersion: version }
       const $ldClient = initialize(clientSideID, context, { ...wrapperOptions, ...options })


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

https://github.com/launchdarkly/vue-client-sdk/issues/54

**Describe the solution you've provided**

- The `streaming` plugin option is now forwarded to the underlying client initialization options.
- `useLDFlag` has been updated to subscribe to `ready` and `change` events even when streaming is disabled.