### PR TITLE
fix: update launchdarkly-js-client-sdk to 3.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "homepage": "https://github.com/launchdarkly/vue-client-sdk#readme",
   "dependencies": {
-    "launchdarkly-js-client-sdk": "3.9.3"
+    "launchdarkly-js-client-sdk": "3.9.4"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality — n/a, dependency bump only
- [x] I have followed the repository's pull request submission guidelines
- [x] I have validated my changes against all supported platform versions

**Related issues**

Propagates the `launchdarkly-js-sdk-common` v5.8.2 bugfix into the Vue SDK via `launchdarkly-js-client-sdk` 3.9.4 (which was just released to pick up common 5.8.2 — https://github.com/launchdarkly/js-client-sdk/pull/349).

**Describe the solution you've provided**

Bump the exact-pinned `launchdarkly-js-client-sdk` dependency from `3.9.3` to `3.9.4`.

```diff
-    "launchdarkly-js-client-sdk": "3.9.3"
+    "launchdarkly-js-client-sdk": "3.9.4"
```

`launchdarkly-js-client-sdk@3.9.4` depends on `launchdarkly-js-sdk-common@5.8.2`, so this transitively pulls in the fix. Verified locally: `npm install` (resolves js-client-sdk 3.9.4 → common 5.8.2), `npm test` (22 passed), `npm run lint`, and `npm run check-typescript` all pass.

**Describe alternatives you've considered**

Leaving the pin as-is — rejected, since the exact pin (`3.9.3`) would otherwise never pick up the released fix.

**Additional context**

Part of rolling out `launchdarkly-js-sdk-common` v5.8.2 across the client-side JS SDKs. Companion PRs: js-client-sdk#349 (merged), node-client-sdk#72 (merged), electron-client-sdk (separate).

Link to Devin session: https://app.devin.ai/sessions/3ed6e570c11b4abb80724e0f2bc5f03e
Requested by: @joker23

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency version bump with no application code changes; risk is limited to behavior in the transitive client SDK/common packages.
> 
> **Overview**
> **Dependency-only change:** the exact pin on `launchdarkly-js-client-sdk` moves from `3.9.3` to `3.9.4` in `package.json`.
> 
> That release pulls in `launchdarkly-js-sdk-common@5.8.2`, propagating the upstream bugfix into the Vue SDK without any Vue binding or source changes in this repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 992de0fb8aefb331bb7d8c72d048e763641aa7a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->